### PR TITLE
Stateful quick start

### DIFF
--- a/demo-suite/app.yaml
+++ b/demo-suite/app.yaml
@@ -1,5 +1,5 @@
 application: gce-demos
-version: 1
+version: marc
 runtime: python27
 api_version: 1
 threadsafe: true

--- a/demo-suite/app.yaml
+++ b/demo-suite/app.yaml
@@ -1,5 +1,5 @@
 application: gce-demos
-version: marc
+version: 1
 runtime: python27
 api_version: 1
 threadsafe: true

--- a/demo-suite/demos/quick-start/main.py
+++ b/demo-suite/demos/quick-start/main.py
@@ -56,6 +56,7 @@ def updateObjective(project_id, targetVMs):
   objective = getObjective(project_id)
   if not objective: 
     logging.info('objective not found, creating new, project=' + project_id)
+    key = ndb.Key("Objective", project_id)
     objective = Objective(key=key)
   objective.targetVMs = targetVMs
   objective.startTime = int(time.time())

--- a/demo-suite/demos/quick-start/main.py
+++ b/demo-suite/demos/quick-start/main.py
@@ -90,7 +90,7 @@ class QuickStart(webapp2.RequestHandler):
     if not oauth_decorator.credentials.refresh_token:
       self.redirect(oauth_decorator.authorize_url() + '&approval_prompt=force')
 
-    targetVMs = 0
+    targetVMs = 5
     startedVMs = 0
     startTime = 0
 

--- a/demo-suite/demos/quick-start/main.py
+++ b/demo-suite/demos/quick-start/main.py
@@ -91,7 +91,7 @@ class QuickStart(webapp2.RequestHandler):
       self.redirect(oauth_decorator.authorize_url() + '&approval_prompt=force')
 
     targetVMs = 5
-    startedVMs = 0
+    startedVMs = 5
     startTime = 0
 
     gce_project_id = data_handler.stored_user_data[user_data.GCE_PROJECT_ID]

--- a/demo-suite/demos/quick-start/static/js/script.js
+++ b/demo-suite/demos/quick-start/static/js/script.js
@@ -46,7 +46,9 @@ QuickStart.prototype.initialize = function() {
       $('#num-instances').val(startedInstances);
       Recovering = true;
       $('#start').click();
-      Recovering = false;
+      if (numInstances == 0) {
+        $('#reset').click();
+      }
       $('#num-instances').val(numInstances);
 
       // In recovery mode, resets are ok but don't let user resend start,
@@ -77,8 +79,8 @@ QuickStart.prototype.initializeButtons_ = function(gce) {
       alert('Max instances is 1000, starting 1000 instead.');
       numInstances = 1000;
     } else if (numInstances < 0) {
-      alert('At least one instance needs to be started, starting 1 instead.');
-      numInstances = 1;
+      alert('At least one instance needs to be started.');
+      return;
     } else if (numInstances === 0) {
       return;
     }
@@ -106,6 +108,9 @@ QuickStart.prototype.initializeButtons_ = function(gce) {
       data: {'num_instances': numInstances},
       callback: function() {
         $('#reset').removeClass('disabled');
+        if (Recovering) {
+          Recovering = false;
+        }
       }
     });
   });
@@ -117,6 +122,9 @@ QuickStart.prototype.initializeButtons_ = function(gce) {
     gce.stopInstances(function() {
       $('#start').removeClass('disabled');
       $('#reset').addClass('disabled');
+      if (Recovering) {
+        Recovering = false;
+      }
     });
   });
 };

--- a/demo-suite/demos/quick-start/static/js/script.js
+++ b/demo-suite/demos/quick-start/static/js/script.js
@@ -42,7 +42,9 @@ QuickStart.prototype.initialize = function() {
       // status polling, we simulate start click with current number of 
       // instances requested, but we set Recovering flag to true to 
       // inhibit sending of start request to GCE.
-      $('#num-instances').val(currentInstances);
+      if (numInstances == 0) {
+        $('#num-instances').val(currentInstances);
+      }
       Recovering = true;
       $('#start').click();
       Recovering = false;

--- a/demo-suite/demos/quick-start/static/js/script.js
+++ b/demo-suite/demos/quick-start/static/js/script.js
@@ -25,10 +25,18 @@ QuickStart.prototype.initialize = function() {
   var gce = new Gce('/' + DEMO_NAME + '/instance',
       '/' + DEMO_NAME + '/instance',
       '/' + DEMO_NAME + '/cleanup');
+
   gce.getInstanceStates(function(data) {
     var numInstances = parseInt($('#num-instances').val(), 10);
     var currentInstances = data['stateCount']['TOTAL'];
     if (currentInstances != 0) {
+      // Alert user we're in recovery mode.
+      //if (numInstances == 0) {
+        //alert('Instances stopping, waiting for completion');
+      //} else {
+        //alert('Instances starting, waiting for completion');
+      //}
+
       // Instance are already running so we're in recovery mode. To draw 
       // grid, maintain counter, and start status polling, we simulate 
       // start click with running current number of instances requested.
@@ -37,6 +45,7 @@ QuickStart.prototype.initialize = function() {
       var startTime = parseInt($('#start-time').val(), 10);
       var currentTime = Math.round(new Date().getTime() / 1000)
       var elapsedTime = currentTime - startTime;
+      Timer.prototype.setOffset(elapsedTime);
 
       $('#num-instances').val(currentInstances);
       Recovering = true;
@@ -48,13 +57,6 @@ QuickStart.prototype.initialize = function() {
       // because duplicate starts can cause confusion and perf problems.
       $('#start').addClass('disabled');
       $('#reset').removeClass('disabled');
-
-      // Alert user we're in recovery mode.
-      if (numInstances == 0) {
-        alert('Instances stopping, waiting for completion');
-      } else {
-        alert('Instances starting, waiting for completion');
-      }
     }
   });
 

--- a/demo-suite/demos/quick-start/static/js/script.js
+++ b/demo-suite/demos/quick-start/static/js/script.js
@@ -34,6 +34,10 @@ QuickStart.prototype.initialize = function() {
       // start click with running current number of instances requested.
       // We also set Recovering flag to true to inhibit sending of start 
       // request to GCE. 
+      var startTime = parseInt($('#start-time').val(), 10);
+      var currentTime = Math.round(new Date().getTime() / 1000)
+      var elapsedTime = currentTime - startTime;
+
       $('#num-instances').val(currentInstances);
       Recovering = true;
       $('#start').click();

--- a/demo-suite/demos/quick-start/static/js/script.js
+++ b/demo-suite/demos/quick-start/static/js/script.js
@@ -16,6 +16,7 @@ $(document).ready(function() {
  */
 var QuickStart = function() { };
 
+// Recovery mode flag, initialized to false.
 var Recovering = false;
 
 /**
@@ -30,23 +31,17 @@ QuickStart.prototype.initialize = function() {
     var numInstances = parseInt($('#num-instances').val(), 10);
     var currentInstances = data['stateCount']['TOTAL'];
     if (currentInstances != 0) {
-      // Alert user we're in recovery mode.
-      //if (numInstances == 0) {
-        //alert('Instances stopping, waiting for completion');
-      //} else {
-        //alert('Instances starting, waiting for completion');
-      //}
-
-      // Instance are already running so we're in recovery mode. To draw 
-      // grid, maintain counter, and start status polling, we simulate 
-      // start click with running current number of instances requested.
-      // We also set Recovering flag to true to inhibit sending of start 
-      // request to GCE. 
+      // Instance are already running so we're in recovery mode. Calculate 
+      // current elapsed time and set timer element accordingly.
       var startTime = parseInt($('#start-time').val(), 10);
       var currentTime = Math.round(new Date().getTime() / 1000)
       var elapsedTime = currentTime - startTime;
       Timer.prototype.setOffset(elapsedTime);
 
+      // In order to draw grid, maintain counter and timer, and start 
+      // status polling, we simulate start click with current number of 
+      // instances requested, but we set Recovering flag to true to 
+      // inhibit sending of start request to GCE.
       $('#num-instances').val(currentInstances);
       Recovering = true;
       $('#start').click();

--- a/demo-suite/demos/quick-start/static/js/script.js
+++ b/demo-suite/demos/quick-start/static/js/script.js
@@ -46,9 +46,6 @@ QuickStart.prototype.initialize = function() {
       $('#num-instances').val(startedInstances);
       Recovering = true;
       $('#start').click();
-      if (numInstances == 0) {
-        $('#reset').click();
-      }
       $('#num-instances').val(numInstances);
 
       // In recovery mode, resets are ok but don't let user resend start,

--- a/demo-suite/demos/quick-start/static/js/script.js
+++ b/demo-suite/demos/quick-start/static/js/script.js
@@ -29,6 +29,7 @@ QuickStart.prototype.initialize = function() {
 
   gce.getInstanceStates(function(data) {
     var numInstances = parseInt($('#num-instances').val(), 10);
+    var startedInstances = parseInt($('#started-instances').val(), 10);
     var currentInstances = data['stateCount']['TOTAL'];
     if (currentInstances != 0) {
       // Instance are already running so we're in recovery mode. Calculate 
@@ -39,12 +40,10 @@ QuickStart.prototype.initialize = function() {
       Timer.prototype.setOffset(elapsedTime);
 
       // In order to draw grid, maintain counter and timer, and start 
-      // status polling, we simulate start click with current number of 
-      // instances requested, but we set Recovering flag to true to 
-      // inhibit sending of start request to GCE.
-      if (numInstances == 0) {
-        $('#num-instances').val(currentInstances);
-      }
+      // status polling, we simulate start click with number of instances 
+      // last started, but we set Recovering flag to true to inhibit 
+      // sending of start request to GCE.
+      $('#num-instances').val(startedInstances);
       Recovering = true;
       $('#start').click();
       Recovering = false;

--- a/demo-suite/demos/quick-start/templates/index.html
+++ b/demo-suite/demos/quick-start/templates/index.html
@@ -29,11 +29,12 @@
 </p>
 
 <p>
-  <input type="text" id="num-instances" value="{{targetVMs}}">
-  <input type="hidden" id="started-instances" value="{{startedVMs}}">
+  <input type="text" id="num-instances" value="{{startedVMs}}">
+  <input type="hidden" id="target-instances" value="{{targetVMs}}">
   <input type="hidden" id="start-time" value="{{startTime}}">
   <a class="btn" id="start">Start</a>
   <a class="btn disabled" id="reset">Reset</a>
+  &nbsp;&nbsp;<span id="in-progress"></span>
 </p>
 
 <div>

--- a/demo-suite/demos/quick-start/templates/index.html
+++ b/demo-suite/demos/quick-start/templates/index.html
@@ -30,6 +30,7 @@
 
 <p>
   <input type="text" id="num-instances" value="{{targetVMs}}">
+  <input type="hidden" id="start-time" value="{{startTime}}">
   <a class="btn" id="start">Start</a>
   <a class="btn disabled" id="reset">Reset</a>
 </p>

--- a/demo-suite/demos/quick-start/templates/index.html
+++ b/demo-suite/demos/quick-start/templates/index.html
@@ -30,6 +30,7 @@
 
 <p>
   <input type="text" id="num-instances" value="{{targetVMs}}">
+  <input type="hidden" id="started-instances" value="{{startedVMs}}">
   <input type="hidden" id="start-time" value="{{startTime}}">
   <a class="btn" id="start">Start</a>
   <a class="btn disabled" id="reset">Reset</a>

--- a/demo-suite/demos/quick-start/templates/index.html
+++ b/demo-suite/demos/quick-start/templates/index.html
@@ -29,7 +29,7 @@
 </p>
 
 <p>
-  <input type="text" id="num-instances" value="5">
+  <input type="text" id="num-instances" value="{{targetVMs}}">
   <a class="btn" id="start">Start</a>
   <a class="btn disabled" id="reset">Reset</a>
 </p>

--- a/demo-suite/static/js/gce.js
+++ b/demo-suite/static/js/gce.js
@@ -9,7 +9,7 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ s WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
@@ -260,7 +260,13 @@ Gce.prototype.heartbeat_ = function(numInstances, callback, terminalState) {
     }
   };
 
+  // If we're in recovery mode (i.e. user refresh the page before request
+  // is complete), start the polling immediately to refresh state ASAP,
+  // instead of waiting 2s to refresh the display.
   var that = this;
+  if (Recovering) {
+    that.getStatuses_(success);
+  }
   setTimeout(function() {
     that.getStatuses_(success);
   }, this.HEARTBEAT_TIMEOUT_);

--- a/demo-suite/static/js/gce.js
+++ b/demo-suite/static/js/gce.js
@@ -169,6 +169,11 @@ Gce.prototype.startInstances = function(numInstances, startOptions) {
  */
 Gce.prototype.stopInstances = function(callback) {
   var data = {}
+
+  if (this.gceUiOptions.timer.start) {
+    this.gceUiOptions.timer.start();
+  }
+
   if (this.commonQueryData_) {
     $.extend(data, this.commonQueryData_)
   }

--- a/demo-suite/static/js/gce.js
+++ b/demo-suite/static/js/gce.js
@@ -264,7 +264,7 @@ Gce.prototype.heartbeat_ = function(numInstances, callback, terminalState) {
   // is complete), start the polling immediately to refresh state ASAP,
   // instead of waiting 2s to refresh the display.
   var that = this;
-  if ((typeof Recovering != undefined) && (!Recovering)) {
+  if ((typeof Recovering != undefined) && Recovering) {
     that.getStatuses_(success);
   } else {
     setTimeout(function() {

--- a/demo-suite/static/js/gce.js
+++ b/demo-suite/static/js/gce.js
@@ -266,10 +266,11 @@ Gce.prototype.heartbeat_ = function(numInstances, callback, terminalState) {
   var that = this;
   if (Recovering) {
     that.getStatuses_(success);
+  } else {
+    setTimeout(function() {
+      that.getStatuses_(success);
+    }, this.HEARTBEAT_TIMEOUT_);
   }
-  setTimeout(function() {
-    that.getStatuses_(success);
-  }, this.HEARTBEAT_TIMEOUT_);
 };
 
 Gce.prototype.continuousHeartbeat_ = function(callback) {

--- a/demo-suite/static/js/gce.js
+++ b/demo-suite/static/js/gce.js
@@ -135,7 +135,7 @@ Gce.prototype.startInstances = function(numInstances, startOptions) {
     }
   }
 
-  if (!Recovering) {
+  if ((typeof Recovering != undefined) && (!Recovering)) {
     var ajaxRequest = {
       type: 'POST',
       url: this.startInstanceUrl_,
@@ -264,7 +264,7 @@ Gce.prototype.heartbeat_ = function(numInstances, callback, terminalState) {
   // is complete), start the polling immediately to refresh state ASAP,
   // instead of waiting 2s to refresh the display.
   var that = this;
-  if (Recovering) {
+  if ((typeof Recovering != undefined) && (!Recovering)) {
     that.getStatuses_(success);
   } else {
     setTimeout(function() {

--- a/demo-suite/static/js/gce.js
+++ b/demo-suite/static/js/gce.js
@@ -135,21 +135,23 @@ Gce.prototype.startInstances = function(numInstances, startOptions) {
     }
   }
 
-  var ajaxRequest = {
-    type: 'POST',
-    url: this.startInstanceUrl_,
-    dataType: 'json',
-    statusCode: this.statusCodeResponseFunctions_,
-    complete: startOptions.ajaxComplete,
-  };
-  ajaxRequest.data = {}
-  if (startOptions.data) {
-    ajaxRequest.data = startOptions.data;
+  if (!Recovering) {
+    var ajaxRequest = {
+      type: 'POST',
+      url: this.startInstanceUrl_,
+      dataType: 'json',
+      statusCode: this.statusCodeResponseFunctions_,
+      complete: startOptions.ajaxComplete,
+    };
+    ajaxRequest.data = {}
+    if (startOptions.data) {
+      ajaxRequest.data = startOptions.data;
+    }
+    if (this.commonQueryData_) {
+      $.extend(ajaxRequest.data, this.commonQueryData_)
+    }
+    $.ajax(ajaxRequest);
   }
-  if (this.commonQueryData_) {
-    $.extend(ajaxRequest.data, this.commonQueryData_)
-  }
-  $.ajax(ajaxRequest);
   if (!this.doContinuousHeartbeat_
     && (this.gceUiOptions || startOptions.callback)) {
     var terminalState = 'RUNNING'

--- a/demo-suite/static/js/gce.js
+++ b/demo-suite/static/js/gce.js
@@ -135,7 +135,7 @@ Gce.prototype.startInstances = function(numInstances, startOptions) {
     }
   }
 
-  if ((typeof Recovering != undefined) && (!Recovering)) {
+  if ((typeof Recovering !== 'undefined') && (!Recovering)) {
     var ajaxRequest = {
       type: 'POST',
       url: this.startInstanceUrl_,

--- a/demo-suite/static/js/timer.js
+++ b/demo-suite/static/js/timer.js
@@ -57,7 +57,6 @@ Timer.prototype.TIMER_INTERVAL_TIME_ = 1000;
  */
 Timer.prototype.running_ = false;
 
-Timer.prototype.TIMER_INTERVAL_TIME_ = 1000;
 /**
  * The elapsed seconds.
  * @type {number}
@@ -86,8 +85,8 @@ Timer.prototype.start = function() {
  * Stop the timer.
  */
 Timer.prototype.stop = function() {
-  clearInterval(this.timerInterval_);
   this.seconds_ = 0;
+  clearInterval(this.timerInterval_);
   Timer.prototype.running_ = false;
 };
 

--- a/demo-suite/static/js/timer.js
+++ b/demo-suite/static/js/timer.js
@@ -51,6 +51,14 @@ Timer.prototype.timerInterval_ = null;
 Timer.prototype.TIMER_INTERVAL_TIME_ = 1000;
 
 /**
+ * The timer state.
+ * @type {boolean}
+ * @private
+ */
+Timer.prototype.running_ = false;
+
+Timer.prototype.TIMER_INTERVAL_TIME_ = 1000;
+/**
  * The elapsed seconds.
  * @type {number}
  * @private
@@ -63,19 +71,32 @@ Timer.prototype.seconds_ = 0;
  */
 Timer.prototype.start = function() {
   var that = this;
-  this.timerInterval_ = setInterval(function() {
-    that.tick_();
-  }, this.TIMER_INTERVAL_TIME_);
-  this.tick_();
+
+  // Start timer if not already running.
+  if (!Timer.prototype.running_) { 
+    this.timerInterval_ = setInterval(function() {
+      that.tick_();
+    }, this.TIMER_INTERVAL_TIME_);
+    this.tick_();
+    Timer.prototype.running_ = true;
+  }
 };
 
 /**
  * Stop the timer.
  */
 Timer.prototype.stop = function() {
-  this.seconds_ = 0;
   clearInterval(this.timerInterval_);
+  this.seconds_ = 0;
+  Timer.prototype.running_ = false;
 };
+
+/**
+ * Set starting offset.
+ */
+Timer.prototype.setOffset = function(offset) {
+  this.seconds_ = offset;
+}
 
 /**
  * Increment the timer every second.


### PR DESCRIPTION
This pull request makes the quick-start demo stateful and recoverable...
- You can reload a demo in progress and it will redraw the grid, adjust the timer to account for actual elapsed time, adjust the counter and pick up where it left off. This makes it easy to recover if you have a fatal error mid-demo - you can simply refresh (or re-create) your browser window and pick up where you left off.
- Made the timer work for a stop/reset request, i.e. you can now tell how long it takes to delete a set of VMs.
- The state info is stored in the app engine datastore and is indexed by project. So my work in progress won't interfere with yours (I won't try to recover your tasks and vice versa) so long as we're using different projects.
